### PR TITLE
HeartBleed should collocate to same node

### DIFF
--- a/heartbleed/hacker.json
+++ b/heartbleed/hacker.json
@@ -38,6 +38,7 @@
         "memMax": 1024,
         "memDefault": 512
     },
-	"authRequired": true,
+    "authRequired": true,
+    "collocate": true,
     "info": "https://cheese-hub.github.io/secure-coding/03-heartbleed/index.html"
 }

--- a/heartbleed/server.json
+++ b/heartbleed/server.json
@@ -20,6 +20,7 @@
         "memMax": 1024,
         "memDefault": 128
     },
-	"authRequired": false,
+    "authRequired": false,
+    "collocate": true,
     "info": "https://cheese-hub.github.io/secure-coding/03-heartbleed/index.html"
 }

--- a/heartbleed/victim.json
+++ b/heartbleed/victim.json
@@ -27,6 +27,7 @@
         "memMax": 1024,
         "memDefault": 512
     },
-	"authRequired": true,
+    "authRequired": true,
+    "collocate": true,
     "info": "https://cheese-hub.github.io/secure-coding/03-heartbleed/index.html"
 }


### PR DESCRIPTION
## Problem
As mentioned during the Cybersecurity Workshop today, HeartBleed should collocate application components to the same node.

## Approach
Enable `collocate=true` flag for HeartBleed